### PR TITLE
CI: Configure jobs based on hierarchy of testing levels (#4)

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -9,24 +9,22 @@ on:
       - '*'
 
 jobs:
-  gradle:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  validate_build:
+    runs-on: macos-latest
     if: ${{ !contains(github.event.head_commit.message, 'ci skip') }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
-
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: '17'
-
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-
-      - name: Run Gradle
-        run: ./gradlew build check --continue
+      - name: Static Analysis
+        run: ./gradlew detekt lint
+      - name: Build
+        run: ./gradlew build
+      - name: Run Unit Tests
+        run: ./gradlew testDebugUnitTest


### PR DESCRIPTION
## The goal

The goal is to make CI run jobs in increasing order of their speed and cost to run. If there's a problem CI should let the developer know as soon as possible without proceeding to more costly verification options. 

## The impact

GitHub CI config.

## The compromises

1. Removed windows and ubuntu OS from the run environments since I think at this stage of the project where I am a sole developer it's a waste of resources. 
2. Wasn't able to parallelize some jobs which could reduce the overall test runtime, but that seems to be due to GitHub Actions not really wanting to support such a thing. There's a lack of feature to inherit the environment from another job regardless if it's marked as `needs`. Every job is completely isolated. So steps of the job can share the same environment. Yet... steps are executed sequentially. 
