### PR TITLE
Card Screen: Keep Screen On

### DIFF
--- a/app/src/main/java/dev/simonas/quies/card/CardScreen.kt
+++ b/app/src/main/java/dev/simonas/quies/card/CardScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +31,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.simonas.quies.data.Question
+import dev.simonas.quies.utils.KeepScreenOn
 import dev.simonas.quies.utils.QDevices
 import dev.simonas.quies.utils.animatePlacement
 import dev.simonas.quies.utils.createTestTag
@@ -83,6 +83,8 @@ internal fun CardScreen(
     onChangeLevel: (Question.Level) -> Unit,
     onBack: () -> Unit,
 ) {
+    KeepScreenOn()
+
     MaterialTheme {
         Scaffold {
             Box(

--- a/app/src/main/java/dev/simonas/quies/utils/KeepScreenOn.kt
+++ b/app/src/main/java/dev/simonas/quies/utils/KeepScreenOn.kt
@@ -1,0 +1,30 @@
+package dev.simonas.quies.utils
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun KeepScreenOn() {
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val window = context.findActivity()?.window
+        window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+}
+
+private fun Context.findActivity(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
+}


### PR DESCRIPTION
## The goal

Remove friction of screen turning off and users fumbling to unlock the device or maintain clicking on the app to not allow it sleep.

## The impact

Card screen.

## The compromises

Battery life.

Screen burn in due to UI components being in the same position for a duration of time.  

Long term this should be combined with in-app dim screensaver.
