### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-05-10
+
+### Changed
+- Updated dependencies and Gradle wrapper.
+- Streamlined CI workflows.
+- Cleaned up Gradle properties and project configuration.
+
+### Removed
+- Removed TROUBLESHOOTING.md and Renovate configuration.
+
 ## [1.0.1] - 2025-09-11
 
 ### Added

--- a/buildSrc/src/main/java/Coordinates.kt
+++ b/buildSrc/src/main/java/Coordinates.kt
@@ -2,6 +2,6 @@ const val PUBLISHING_GROUP = "dev.simonas"
 
 object AppCoordinates {
     const val APP_ID = "dev.simonas.quies"
-    const val APP_VERSION_NAME = "1.0.1"
-    const val APP_VERSION_CODE = 33
+    const val APP_VERSION_NAME = "1.0.2"
+    const val APP_VERSION_CODE = 34
 }


### PR DESCRIPTION
Release 1.0.2 — patch.

Bumps `APP_VERSION_NAME` to 1.0.2 and `APP_VERSION_CODE` to 34, and adds the corresponding `CHANGELOG.md` entry.

## Changes since v1.0.1

### Changed
- Updated dependencies and Gradle wrapper.
- Streamlined CI workflows.
- Cleaned up Gradle properties and project configuration.

### Removed
- Removed TROUBLESHOOTING.md and Renovate configuration.